### PR TITLE
Implement VERSION command [fisttp]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased - master]
+- Added support for VERSION command
 
 ## [0.0.1 - 2019-07-03]
 - Added support for EXIT command

--- a/client/client.go
+++ b/client/client.go
@@ -21,6 +21,7 @@ type FistClient struct {
 // of it.
 func NewFistClient(host string, port string) (*FistClient, error) {
 	conn, err := net.Dial("tcp", net.JoinHostPort(host, port))
+	// TODO: Add support to configure timeout
 	if err != nil {
 		log.Print(err)
 		return nil, err
@@ -67,6 +68,16 @@ func (fc *FistClient) Search(payload string) []string {
 		return sResponse.Documents
 	}
 	return nil
+}
+
+func (fc *FistClient) Version() (string, error) {
+	request := fisttp.NewVersionRequest()
+	response := fc.dispatchRequest(request)
+	if response.IsOk() {
+		vResponse := response.(*fisttp.VersionResponse)
+		return vResponse.GetVersion(), nil
+	}
+	return "", fmt.Errorf("version could not be retrieved")
 }
 
 // Exit command will terminate a connection

--- a/examples/quickStart.go
+++ b/examples/quickStart.go
@@ -7,6 +7,9 @@ import (
 
 func main() {
 	client, _ := fistclient.NewFistClient("localhost", "5575")
+	// Obtain server version
+	version, _ := client.Version()
+	fmt.Println("Server version is " + version)
 	// Index some data
 	client.Index("todo", "wash the car")
 	client.Index("todo", "walk the dog")

--- a/fisttp/constants.go
+++ b/fisttp/constants.go
@@ -5,7 +5,8 @@ type Verb string
 
 // This is a list of currently implemented commands
 const (
-	INDEX  Verb = "INDEX"  // Request the server to index a document
-	SEARCH      = "SEARCH" // Query the server to find a matching document for a custom payload
-	EXIT        = "EXIT"   // Request to server to terminate the session gracefully
+	INDEX   Verb = "INDEX"   // Request the server to index a document
+	SEARCH       = "SEARCH"  // Query the server to find a matching document for a custom payload
+	EXIT         = "EXIT"    // Request to server to terminate the session gracefully
+	VERSION      = "VERSION" // Request the server to get the server version
 )

--- a/fisttp/request.go
+++ b/fisttp/request.go
@@ -89,3 +89,21 @@ func (er *SearchRequest) String() string {
 func (er *SearchRequest) Type() Verb {
 	return SEARCH
 }
+
+// VersionRequest represents a query to the server in order to
+// find out the version of it
+type VersionRequest struct {}
+
+// NewVersionRequest returns a newly allocated VersionRequest
+func NewVersionRequest() *VersionRequest {
+	return &VersionRequest{}
+}
+
+// Type returns the type of the request. VERSION will be issued
+func (vr *VersionRequest) Type() Verb {
+	return VERSION
+}
+
+func (vr *VersionRequest) String() string {
+	return string(VERSION) + "\n"
+}

--- a/fisttp/response.go
+++ b/fisttp/response.go
@@ -44,3 +44,20 @@ func (er *ExitResponse) responseElement() {}
 func (er *ExitResponse) IsOk() bool {
 	return er.Ok
 }
+
+// VersionResponse carries the version issued by the server
+type VersionResponse struct {
+	version string
+}
+
+// IsOk returns whether a valid version string has been obtained
+func (vr *VersionResponse) IsOk() bool {
+	return len(vr.version) > 0
+}
+
+// GetVersion returns the version from the server response
+func (vr *VersionResponse) GetVersion() string {
+	return vr.version
+}
+
+func (vr *VersionResponse) responseElement() {}

--- a/fisttp/response_parser.go
+++ b/fisttp/response_parser.go
@@ -27,6 +27,12 @@ func parseExitResponse(payload []byte) *ExitResponse {
 	}
 }
 
+func parseVersionResponse(payload []byte) *VersionResponse {
+	return &VersionResponse{
+		version: strings.TrimSpace(string(payload)),
+	}
+}
+
 // ParseResponse will return the corresponding type of response
 // by given the Verb/Command of the request and resulting body
 // payload from server
@@ -38,6 +44,8 @@ func ParseResponse(verb Verb, payload []byte) Response {
 		return parseSearchResponse(payload)
 	case EXIT:
 		return parseExitResponse(payload)
+	case VERSION:
+		return parseVersionResponse(payload)
 	}
 	return nil
 }

--- a/fisttp/response_parser_test.go
+++ b/fisttp/response_parser_test.go
@@ -49,6 +49,21 @@ func assertSearchResponseEqual(t *testing.T, expected *SearchResponse, actual Re
 	return true
 }
 
+func assertVersionResponseEqual(t *testing.T, expected *VersionResponse, actual Response) bool {
+	actualResponse, ok := actual.(*VersionResponse)
+	if !ok {
+		t.Errorf("wrong response type. want '%T', have '%T'",
+			expected, actualResponse)
+		return false
+	}
+	if expected.GetVersion() != actualResponse.GetVersion() {
+		t.Errorf("wrong version. want '%s', have '%s'",
+			expected.GetVersion(), actualResponse.GetVersion())
+		return false
+	}
+	return true
+}
+
 func assertExitResponseEqual(t *testing.T, expected *ExitResponse, actual Response) bool {
 	if actualResponseType, ok := actual.(*ExitResponse); !ok {
 		t.Errorf("wrong response type. want '%T', have '%T'",
@@ -73,6 +88,8 @@ func assertResponseEqual(t *testing.T, expected Response, actual Response) bool 
 		return assertSearchResponseEqual(t, expectedResponse, actual)
 	case *ExitResponse:
 		return assertExitResponseEqual(t, expectedResponse, actual)
+	case *VersionResponse:
+		return assertVersionResponseEqual(t, expectedResponse, actual)
 	}
 	return true
 }
@@ -103,6 +120,12 @@ func runExitResponseParserTests(t *testing.T, tests []ResponseParserTest) {
 	t.Helper()
 
 	runResponseParserTests(t, EXIT, tests)
+}
+
+func runVersionResponseParserTests(t *testing.T, tests []ResponseParserTest) {
+	t.Helper()
+
+	runResponseParserTests(t, VERSION, tests)
 }
 
 func TestParseIndexResponse(t *testing.T) {
@@ -189,4 +212,23 @@ func TestParseExitResponse(t *testing.T) {
 	}
 
 	runExitResponseParserTests(t, tests)
+}
+
+func TestParseVersionResponse(t *testing.T) {
+	tests := []ResponseParserTest{
+		{
+			"0.0.0",
+			&VersionResponse{
+				version: "0.0.0",
+			},
+		},
+		{
+			" 0.0.0 ",
+			&VersionResponse{
+				version: "0.0.0",
+			},
+		},
+	}
+
+	runVersionResponseParserTests(t, tests)
 }


### PR DESCRIPTION
This commit alters the fisttp package to add the new version
command available from 0.0.2 fist server version on. This command
tells the server to send back the version of that running server
instance.

Closes: https://github.com/sonirico/go-fist/issues/2