### PR TITLE
Fixes client hanging after sending request (ref #2)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -70,6 +70,7 @@ func (fc *FistClient) Search(payload string) []string {
 	return nil
 }
 
+// Version command will pull the server version
 func (fc *FistClient) Version() (string, error) {
 	request := fisttp.NewVersionRequest()
 	response := fc.dispatchRequest(request)

--- a/fisttp/constants.go
+++ b/fisttp/constants.go
@@ -10,3 +10,6 @@ const (
 	EXIT         = "EXIT"    // Request to server to terminate the session gracefully
 	VERSION      = "VERSION" // Request the server to get the server version
 )
+
+// REOL marks the end of a request
+const REOL = "\r\n"

--- a/fisttp/request.go
+++ b/fisttp/request.go
@@ -14,7 +14,7 @@ type Request interface {
 type ExitRequest struct{}
 
 func (er *ExitRequest) String() string {
-	return string(EXIT) + "\n"
+	return string(EXIT) + REOL
 }
 
 // Type gets the type of the request. EXIT will be issued
@@ -50,7 +50,7 @@ func (er *IndexRequest) String() string {
 	out.WriteString(er.document)
 	out.WriteString(" ")
 	out.WriteString(er.payload)
-	out.WriteString("\n")
+	out.WriteString(REOL)
 
 	return out.String()
 }
@@ -80,7 +80,7 @@ func (er *SearchRequest) String() string {
 	out.WriteString(string(er.Type()))
 	out.WriteString(" ")
 	out.WriteString(er.payload)
-	out.WriteString("\n")
+	out.WriteString(REOL)
 
 	return out.String()
 }
@@ -92,7 +92,7 @@ func (er *SearchRequest) Type() Verb {
 
 // VersionRequest represents a query to the server in order to
 // find out the version of it
-type VersionRequest struct {}
+type VersionRequest struct{}
 
 // NewVersionRequest returns a newly allocated VersionRequest
 func NewVersionRequest() *VersionRequest {
@@ -105,5 +105,5 @@ func (vr *VersionRequest) Type() Verb {
 }
 
 func (vr *VersionRequest) String() string {
-	return string(VERSION) + "\n"
+	return string(VERSION) + REOL
 }


### PR DESCRIPTION
fist>=0.0.1 enforced client commands to end with '\r\n' instead
of '\n' as the initial implementation was doing.

This commit also introduces the usage of a constant 'REOL' to fix
request end-of-line to less volatile name.