### PR TITLE
Feature support for DELETE command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased - master]
+- Commands:
+    - Added support for DELETE command
+    - Added support for VERSION command
 - Swap to relative imports
-- Added support for VERSION command
 - Fixed client hanging after sending requests due to bad
   terminator chars
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,30 @@ go get -u github.com/sonirico/go-fist
 ## Examples
 
 ```go
-client, _ := fistclient.NewFistClient("localhost", "5575")
+import fistClient "github.com/sonirico/go-fist"
+
+// ...
+
+client, err := fistClient.NewFistClient("localhost", "5575")
+if err != nil {
+    fmt.Println("Connection Error! Is Fist up and running?")
+    return
+}
+// Obtain server version
+version, _ := client.Version()
+fmt.Println("Server version is " + version)
 // Index some data
-client.Index("todo", "wash the car")
-client.Index("todo", "walk the dog")
+client.Index("articles", "a an the")
+client.Index("TODO", "wash the car")
+client.Index("TODO", "walk the dog")
 client.Index("podcasts", "DSE - Daily software engineering")
-// Search for it
+// Search for "the" keyword
 documents := client.Search("the")
-fmt.Println(documents) // ["todo"]
+fmt.Println(documents) // ["articles", "TODO"]
+// Not needing articles?
+client.Delete("the")
+documents = client.Search("the")
+fmt.Println(documents) // []
 ```
 
 More detailed examples can be found under the `./examples` subpackage

--- a/client/client.go
+++ b/client/client.go
@@ -69,6 +69,13 @@ func (fc *FistClient) Search(payload string) []string {
 	return nil
 }
 
+// Delete command will remove the given keyword set from all documents
+func (fc *FistClient) Delete(payload string) bool {
+	request := fisttp.NewDeleteRequest(payload)
+	response := fc.dispatchRequest(request)
+	return response.IsOk()
+}
+
 // Version command will pull the server version
 func (fc *FistClient) Version() (string, error) {
 	request := fisttp.NewVersionRequest()

--- a/examples/quickStart.go
+++ b/examples/quickStart.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	fistclient "go-fist/client"
+	fistClient "go-fist/client"
 )
 
 func main() {
-	client, err := fistclient.NewFistClient("localhost", "55750")
+	client, err := fistClient.NewFistClient("localhost", "5575")
 	if err != nil {
 		fmt.Println("Connection Error! Is Fist up and running?")
 		return
@@ -15,10 +15,15 @@ func main() {
 	version, _ := client.Version()
 	fmt.Println("Server version is " + version)
 	// Index some data
-	client.Index("todo", "wash the car")
-	client.Index("todo", "walk the dog")
+	client.Index("articles", "a an the")
+	client.Index("TODO", "wash the car")
+	client.Index("TODO", "walk the dog")
 	client.Index("podcasts", "DSE - Daily software engineering")
-	// Search for it
+	// Search for "the" keyword
 	documents := client.Search("the")
-	fmt.Println(documents) // ["todo"]
+	fmt.Println(documents) // ["articles", "TODO"]
+	// Not needing articles?
+	client.Delete("the")
+	documents = client.Search("the")
+	fmt.Println(documents) // []
 }

--- a/fisttp/constants.go
+++ b/fisttp/constants.go
@@ -9,6 +9,7 @@ const (
 	SEARCH       = "SEARCH"  // Query the server to find a matching document for a custom payload
 	EXIT         = "EXIT"    // Request to server to terminate the session gracefully
 	VERSION      = "VERSION" // Request the server to get the server version
+	DELETE		 = "DELETE"  // Request the server to remove a set of keywords from all documents
 )
 
 // REOL marks the end of a request

--- a/fisttp/request.go
+++ b/fisttp/request.go
@@ -90,6 +90,34 @@ func (er *SearchRequest) Type() Verb {
 	return SEARCH
 }
 
+// DeleteRequest requests the action of keyword removal. Will
+// apply to all documents
+type DeleteRequest struct {
+	keywords string
+}
+
+// NewDeleteRequest returns a newly allocated DeleteRequest which
+// will carry the keywords to be deleted
+func NewDeleteRequest(payload string) *DeleteRequest {
+	return &DeleteRequest{keywords: payload}
+}
+
+// Type gets the type of the request. DELETE will be issued
+func (dr *DeleteRequest) Type() Verb {
+	return DELETE
+}
+
+func (dr *DeleteRequest) String() string {
+	var out bytes.Buffer
+
+	out.WriteString(string(dr.Type()))
+	out.WriteString(" ")
+	out.WriteString(dr.keywords)
+	out.WriteString(REOL)
+
+	return out.String()
+}
+
 // VersionRequest represents a query to the server in order to
 // find out the version of it
 type VersionRequest struct{}

--- a/fisttp/response.go
+++ b/fisttp/response.go
@@ -61,3 +61,15 @@ func (vr *VersionResponse) GetVersion() string {
 }
 
 func (vr *VersionResponse) responseElement() {}
+
+// DeleteResponse holds whether keyword deletion has been successful
+type DeleteResponse struct {
+	ok bool
+}
+
+// IsOk returns whether deletion has been rightly performed
+func (dr *DeleteResponse) IsOk() bool {
+	return dr.ok
+}
+
+func (dr *DeleteResponse) responseElement() {}

--- a/fisttp/response_parser.go
+++ b/fisttp/response_parser.go
@@ -33,6 +33,12 @@ func parseVersionResponse(payload []byte) *VersionResponse {
 	}
 }
 
+func parseDeleteResponse(payload []byte) *DeleteResponse {
+	return &DeleteResponse{
+		ok: strings.TrimSpace(string(payload)) == "Key Removed",
+	}
+}
+
 // ParseResponse will return the corresponding type of response
 // by given the Verb/Command of the request and resulting body
 // payload from server
@@ -42,6 +48,8 @@ func ParseResponse(verb Verb, payload []byte) Response {
 		return parseIndexResponse(payload)
 	case SEARCH:
 		return parseSearchResponse(payload)
+	case DELETE:
+		return parseDeleteResponse(payload)
 	case EXIT:
 		return parseExitResponse(payload)
 	case VERSION:

--- a/fisttp/response_parser_test.go
+++ b/fisttp/response_parser_test.go
@@ -73,6 +73,15 @@ func assertExitResponseEqual(t *testing.T, expected *ExitResponse, actual Respon
 	return true
 }
 
+func assertDeleteResponseEqual(t *testing.T, expected *DeleteResponse, actual Response) bool {
+	if actualResponseType, ok := actual.(*DeleteResponse); !ok {
+		t.Errorf("wrong response type. want '%T', have '%T'",
+			expected, actualResponseType)
+		return false
+	}
+	return true
+}
+
 func assertResponseEqual(t *testing.T, expected Response, actual Response) bool {
 	t.Helper()
 
@@ -90,6 +99,8 @@ func assertResponseEqual(t *testing.T, expected Response, actual Response) bool 
 		return assertExitResponseEqual(t, expectedResponse, actual)
 	case *VersionResponse:
 		return assertVersionResponseEqual(t, expectedResponse, actual)
+	case *DeleteResponse:
+		return assertDeleteResponseEqual(t, expectedResponse, actual)
 	}
 	return true
 }
@@ -126,6 +137,12 @@ func runVersionResponseParserTests(t *testing.T, tests []ResponseParserTest) {
 	t.Helper()
 
 	runResponseParserTests(t, VERSION, tests)
+}
+
+func runDeleteResponseParserTests(t *testing.T, tests []ResponseParserTest) {
+	t.Helper()
+
+	runResponseParserTests(t, DELETE, tests)
 }
 
 func TestParseIndexResponse(t *testing.T) {
@@ -231,4 +248,29 @@ func TestParseVersionResponse(t *testing.T) {
 	}
 
 	runVersionResponseParserTests(t, tests)
+}
+
+func TestParseDeleteResponse(t *testing.T) {
+	tests := []ResponseParserTest{
+		{
+			"Key Removed",
+			&DeleteResponse{
+				ok: true,
+			},
+		},
+		{
+			" Key Removed ",
+			&DeleteResponse{
+				ok: true,
+			},
+		},
+		{
+			" whatever nosense",
+			&DeleteResponse{
+				ok: false,
+			},
+		},
+	}
+
+	runDeleteResponseParserTests(t, tests)
 }


### PR DESCRIPTION
In this commit support for keyword deletion has been implemented. This
new command will iterate over all available documents and will remove
the keywords issued by the client from all of them.